### PR TITLE
added LICENSE to MANIFEST.in for sdist, see #7

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
+include LICENSE
 include requirements.txt
 recursive-include lib *.ini


### PR DESCRIPTION
many thanks for the fast reaction, I guess we have to solve it in MANIFEST.in

`python setup.py sdist --formats=zip,gztar,bztar`

and verification

```
tar zxvf nappy-1.2.0.tar.gz | grep LICENSE
> nappy-1.2.0/LICENSE
```
