### PR TITLE
Added support for all NDACC AMES file variants

### DIFF
--- a/nappy/na_file/na_file.py
+++ b/nappy/na_file/na_file.py
@@ -184,6 +184,9 @@ class NAFile(nappy.na_file.na_core.NACore):
         """
         Reads the header section common to all NASA Ames files.
         """
+        for i in range(self.ignore_header_lines):
+            self.ignored_header_lines.append(nappy.utils.text_parser.readItemFromLine(self.file.readline()))
+        
         self._readTopLine()
         self.ONAME = nappy.utils.text_parser.readItemFromLine(self.file.readline(), str)
         self.ORG = nappy.utils.text_parser.readItemFromLine(self.file.readline(), str)
@@ -192,6 +195,7 @@ class NAFile(nappy.na_file.na_core.NACore):
         (self.IVOL, self.NVOL) = nappy.utils.text_parser.readItemsFromLine(self.file.readline(), 2, int)
         dates = nappy.utils.text_parser.readItemsFromLine(self.file.readline(), 6, int)
         (self.DATE, self.RDATE) = (dates[:3], dates[3:])
+        self.NLHEAD += self.ignore_header_lines
 
     def _writeCommonHeader(self):
         """

--- a/nappy/na_file/na_file_2160.py
+++ b/nappy/na_file/na_file_2160.py
@@ -31,11 +31,7 @@ class NAFile2160(nappy.na_file.na_file_2110.NAFile2110):
         """
         self._normalized_X = False
         
-        for i in range(self.ignore_header_lines):
-            self.ignored_header_lines.append(nappy.utils.text_parser.readItemFromLine(self.file.readline()))
-
         self._readCommonHeader()
-        self.NLHEAD += self.ignore_header_lines
         self.DX = nappy.utils.text_parser.readItemsFromLine(self.file.readline(), 1, float)
         self.LENX = nappy.utils.text_parser.readItemFromLine(self.file.readline(), float)
         self.XNAME = nappy.utils.text_parser.readItemsFromLines(self._readLines(self.NIV), self.NIV, str)


### PR DESCRIPTION
- Update the _readCommonHeader() function in na_file.py to let to ignore first lines in all types of files; solution used before in readHeader() function in na_file_2160.py
- Removal of the same lines in readHeader() function in na_file_2160.py in order to avoid redundancy