### PR TITLE
Remove logging basic configuration to make logging configuration on application level working

### DIFF
--- a/nappy/nappy_api.py
+++ b/nappy/nappy_api.py
@@ -123,7 +123,6 @@ ffi = nappy.chooseFFI(na_dict)
 
 # Import standard library modules
 import logging
-logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
 
 # Import local modules

--- a/nappy/nc_interface/na_content_collector.py
+++ b/nappy/nc_interface/na_content_collector.py
@@ -37,7 +37,6 @@ hp = header_partitions
 version = nappy.utils.getVersion()
 DEBUG = nappy.utils.getDebug() 
 
-logging.basicConfig()
 log = logging.getLogger(__name__)
 
 

--- a/nappy/nc_interface/na_to_nc.py
+++ b/nappy/nc_interface/na_to_nc.py
@@ -21,7 +21,6 @@ import numpy as np
 # Import from nappy package
 import nappy.nc_interface.na_to_xarray
 
-logging.basicConfig()
 log = logging.getLogger(__name__)
 
 

--- a/nappy/nc_interface/na_to_xarray.py
+++ b/nappy/nc_interface/na_to_xarray.py
@@ -57,7 +57,6 @@ Where:
 
 DEBUG = nappy.utils.getDebug() 
 
-logging.basicConfig()
 log = logging.getLogger(__name__)
 
 

--- a/nappy/nc_interface/nc_to_na.py
+++ b/nappy/nc_interface/nc_to_na.py
@@ -24,7 +24,6 @@ import nappy.utils
 import nappy.utils.common_utils
 import nappy.nc_interface.xarray_to_na
 
-logging.basicConfig()
 log = logging.getLogger(__name__)
 
 

--- a/nappy/nc_interface/xarray_objs_to_na_files.py
+++ b/nappy/nc_interface/xarray_objs_to_na_files.py
@@ -27,7 +27,6 @@ default_delimiter = nappy.utils.getDefault("default_delimiter")
 default_float_format = nappy.utils.getDefault("default_float_format")
 
 # Define logger
-logging.basicConfig()
 log = logging.getLogger(__name__)
 
 

--- a/nappy/nc_interface/xarray_to_na.py
+++ b/nappy/nc_interface/xarray_to_na.py
@@ -45,7 +45,6 @@ var_limit = 5000 # surely never going to get this many vars in a file!
 
 DEBUG = nappy.utils.getDebug() 
 
-logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
 
 

--- a/nappy/utils/common_utils.py
+++ b/nappy/utils/common_utils.py
@@ -18,7 +18,6 @@ import logging
 from nappy.utils import parse_config
 from nappy.utils import text_parser
 
-logging.basicConfig()
 log = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Logging is configured In nappy using `logging.basicConfig()`. When applying nappy in other applications with their own logging configuration, this lead to conflicts. 

For scripts in nappy logging might be configured only subsequent ... 
 ```
if __name__ == '__main__':
    # configure logging
    # logging.basicConfig(level=logging.INFO)
    ...
```