### PR TITLE
use __version__ from nappy init instead of version parameter from ini file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ pip-log.txt
 pip-delete-this-directory.txt
 
 # Unit test / coverage reports
+tests/test_outputs
+tests/cached_outputs
 htmlcov/
 .tox/
 .coverage

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ setup_env.sh
 
 # Pycharm files
 .idea
+
+# VS Code files
+*.code-workspace

--- a/nappy/config/nappy.ini
+++ b/nappy/config/nappy.ini
@@ -1,5 +1,5 @@
 [main]
-version = 0.3.0
+; deprecated: version = 0.3.0
 DEBUG = False
 default_delimiter = __space____space____space____space__
 default_float_format = %.10g

--- a/nappy/utils/common_utils.py
+++ b/nappy/utils/common_utils.py
@@ -17,6 +17,7 @@ import logging
 import numpy as np
 
 # Imports from local package
+from nappy import __version__
 from nappy.utils import parse_config
 from nappy.utils import text_parser
 
@@ -132,8 +133,9 @@ def getVersion():
     """
     Gets config dict for version.
     """
-    version = parse_config.getConfigDict()["main"]["version"]
-    return version
+    # deprecated:
+    # version = parse_config.getConfigDict()["main"]["version"]
+    return __version__
 
 
 def getDebug():


### PR DESCRIPTION
Addresses https://github.com/cedadev/nappy/issues/49 - this PR deprecates the `version` parameter from the [nappy.ini](https://github.com/cedadev/nappy/blob/main/nappy/config/nappy.ini) file. Instead, `nappy.__version__` is now used consistently throughout the code (e.g. when specifying the nappy version during the conversion of an NA file to netCDF).

API unchanged. No test added (but could do so).

Note: I see this more as a temporary fix. Ideally, package version is managed by the CI workflow e.g. derived from the latest git tag. @agstephens don't know what your plans are in that respect.

cheers, Florian
